### PR TITLE
Require ruby gems in flea

### DIFF
--- a/lib/flea/standard_library/require_library.scm
+++ b/lib/flea/standard_library/require_library.scm
@@ -1,0 +1,6 @@
+(define require 
+  (native_function "
+    Proc.new do |arguments, interpreter|
+      arguments[0][1].each {|x| require x} unless arguments.empty? && arguments[0][1].nil?
+    end 
+  "))


### PR DESCRIPTION
allow flea to require ruby gems. It's pretty neat.

usage: (require '("rack" "time" "benchmark"))
