### PR TITLE
Remove all warnings when running spec and install tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,10 +11,12 @@ begin
     gemspec.email = "aaron@aarongough.com"
     gemspec.homepage = "http://github.com/aarongough/flea"
     gemspec.authors = ["Aaron Gough"]
+    gemspec.license = "MIT"
     gemspec.rdoc_options << '--line-numbers' << '--inline-source'
     gemspec.extra_rdoc_files = ['README.rdoc', 'MIT-LICENSE']
-    gemspec.add_dependency "sexpistol"
-    gemspec.add_development_dependency "any-spec"
+    gemspec.add_dependency "sexpistol", "= 0.0.7"
+    gemspec.add_development_dependency "any-spec", "= 0.1.0"
+    gemspec.add_development_dependency "rspec", "= 3.3.0"
     gemspec.executables << 'flea'
   end
 rescue LoadError

--- a/lib/flea/standard_library/lambda.scm
+++ b/lib/flea/standard_library/lambda.scm
@@ -1,21 +1,22 @@
-(define lambda 
+(define lambda
   (native_function "
     Proc.new() do |arguments, interpreter|
       formals = arguments[0]
       body = arguments.slice(1, arguments.length)
-      
+
       if formals.is_a? Array
         # detect if any formal names have been used more than once
-        error_message = 'Formal {FORMAL} declared more than once' 
-        formals.each_index do |x| 
+        error_message = 'Formal {FORMAL} declared more than once'
+        formals.each_index do |x|
           tmp = formals.dup
           tmp.delete_at(x)
-          raise(error_message.gsub('{FORMAL}', formals[x])) if tmp.include? formals[x] 
+
+          raise(error_message.gsub('{FORMAL}', formals[x].to_s)) if tmp.include? formals[x]
         end
       end
-      
+
       sub_env = Flea::Environment.new(interpreter.current_environment)
-      
+
       execute_body = Proc.new() do |body, environment, interpreter|
         interpreter.current_environment = environment
         result = nil
@@ -24,8 +25,8 @@
         end
         interpreter.current_environment = environment.parent
         result
-      end    
-      
+      end
+
       if formals.is_a?(Array) && formals.include?(:'.')
         Proc.new() do |arguments, interpreter|
           args = arguments.dup
@@ -37,7 +38,7 @@
           sub_env.define(list_formal, args)
           execute_body.call(body, sub_env, interpreter)
         end
-        
+
       elsif formals.is_a? Array
         Proc.new() do |arguments, interpreter|
           formals.each_index do |i|
@@ -45,7 +46,7 @@
           end
           execute_body.call(body, sub_env, interpreter)
         end
-        
+
       elsif formals.is_a? Symbol
         Proc.new() do |arguments, interpreter|
           arguments = arguments.map {|x| interpreter.evaluate(x) }

--- a/lib/flea/standard_library/set.scm
+++ b/lib/flea/standard_library/set.scm
@@ -2,7 +2,7 @@
   (native_function "
     Proc.new() do |arguments, interpreter|
       if( interpreter.current_environment.find(arguments[0]) == nil)
-        raise 'Cannot set unbound variable ' + arguments[0]
+        raise 'Cannot set unbound variable ' + arguments[0].to_s
       end
       interpreter.current_environment.define(arguments[0], arguments[1])
     end

--- a/spec/flea/environment_spec.rb
+++ b/spec/flea/environment_spec.rb
@@ -2,111 +2,109 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "Flea" do
   describe "::Environment" do
-    
-    include Flea
-    
+
     describe ".new" do
       it "should return an environment object" do
-        Environment.new.should be_an Environment
+        expect(Flea::Environment.new).to be_a Flea::Environment
       end
-      
+
       it "should return an environment object with no parent" do
-        environment = Environment.new
-        environment.parent.should be_nil
+        environment = Flea::Environment.new
+        expect(environment.parent).to be_nil
       end
-      
+
       it "should return an environment object with the specified parent" do
-        parent_environment = mock("Environment")
-        environment = Environment.new(parent_environment)
-        environment.parent.should be parent_environment
+        parent_environment = double("Flea::Environment")
+        environment = Flea::Environment.new(parent_environment)
+        expect(environment.parent).to be parent_environment
       end
-      
+
       it "should add base variables for #t and #f" do
-        environment = Environment.new
-        environment.should have_variable :"#t"
-        environment.should have_variable :"#f"
-        environment.find(:"#t").should be_true
-        environment.find(:"#f").should be_false
+        environment = Flea::Environment.new
+        expect(environment).to have_variable :"#t"
+        expect(environment).to have_variable :"#f"
+        expect(environment.find(:"#t")).to be true
+        expect(environment.find(:"#f")).to be false
       end
     end
-    
+
     describe "#has_variable?" do
       context "without a parent" do
         before :each do
-          @environment = Environment.new
+          @environment = Flea::Environment.new
         end
-        
+
         it "should return false if the variable is not set in the current environment" do
-          @environment.should_not have_variable :test
+          expect(@environment).not_to have_variable :test
         end
-        
+
         it "should return true if the variable is set in the current environment" do
           @environment.define(:test, 1)
-          @environment.should have_variable :test
+          expect(@environment).to have_variable :test
         end
       end
-      
+
       context "with a parent" do
         before :each do
-          @parent_environment = Environment.new
-          @environment = Environment.new(@parent_environment)
+          @parent_environment = Flea::Environment.new
+          @environment = Flea::Environment.new(@parent_environment)
         end
-        
+
         it "should return false if the variable is not set in the parent environment" do
-          @environment.should_not have_variable :test
+          expect(@environment).to_not have_variable :test
         end
-        
+
         it "should return true if the variable is set in the parent environment" do
           @parent_environment.define(:test, 1)
-          @environment.should have_variable :test
+          expect(@environment).to have_variable :test
         end
       end
     end
-    
+
     describe "#define" do
       it "should set a variable to the supplied value" do
-        env = Environment.new
+        env = Flea::Environment.new
         result = env.define(:test, 1)
-        env.should have_variable :test
-        env.find(:test).should == 1
-        result.should == 1
+        expect(env).to have_variable :test
+        expect(env.find(:test)).to be == 1
+        expect(result).to be == 1
       end
     end
-    
+
     describe "#find" do
       context "without a parent" do
         before :each do
-          @environment = Environment.new
+          @environment = Flea::Environment.new
           @environment.define(:test, 1)
         end
-        
+
         it "should find a variable in the current environment" do
-          @environment.find(:test).should == 1
+          expect(@environment.find(:test)).to be == 1
         end
-        
+
         it "should return nil when variable is not set" do
-          @environment.find(:fake).should be_nil
+          expect(@environment.find(:fake)).to be_nil
         end
       end
-      
+
       context "with a parent" do
         before :each do
-          @parent_environment = Environment.new
-          @environment = Environment.new(@parent_environment)
+          @parent_environment = Flea::Environment.new
+          @environment = Flea::Environment.new(@parent_environment)
           @parent_environment.define(:test, 1)
         end
-        
+
         it "should find a variable in the parent environment" do
-          @environment.find(:test).should == 1
+          expect(@environment.find(:test)).to be == 1
         end
-        
+
         it "should return a variable from the current environment if it is set in both current and parent" do
           @environment.define(:test, 5)
-          @environment.find(:test).should == 5
+          expect(@environment.find(:test)).to be == 5
         end
-        
+
         it "should return nil when variable is not set in the current or parent environment" do
-          @environment.find(:fake).should be_nil
+          expect(@environment.find(:fake)).to be_nil
         end
       end
     end

--- a/spec/flea/interpreter_spec.rb
+++ b/spec/flea/interpreter_spec.rb
@@ -1,85 +1,83 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "Flea" do
-  describe "::Interpreter" do
-    
-    include Flea
-   
+  describe "Flea::Interpreter" do
+
     describe "#new" do
       it "should return an Interpreter" do
-        Interpreter.new.should be_an Interpreter
+        expect(Flea::Interpreter.new).to be_a Flea::Interpreter
       end
-      
+
       it "should allow setting the base environment to use" do
-        environment = mock("Environment")
-        interpreter = Interpreter.new(
+        environment = double("Flea::Environment")
+        interpreter = Flea::Interpreter.new(
           :base_environment => environment,
           :load_standard_library => false
         )
-        interpreter.base_environment.should be environment
+        expect(interpreter.base_environment).to be environment
       end
     end
-    
+
     describe ".run" do
       it "should run a program and return the last output from the program" do
-        interpreter = Interpreter.new
+        interpreter = Flea::Interpreter.new
         result = interpreter.run("(define test 1)")
-        result.should == 1
-        interpreter.base_environment.should have_variable :test
+        expect(result).to be == 1
+        expect(interpreter.base_environment).to have_variable :test
       end
     end
-    
+
     describe ".parse" do
       it "should return an abstract syntax tree representing the supplied program" do
-        ast = Interpreter.new.parse("(define test 1)")
-        ast.should == [[:define, :test, 1]]
+        ast = Flea::Interpreter.new.parse("(define test 1)")
+        expect(ast).to be == [[:define, :test, 1]]
       end
     end
-    
+
     describe ".evaluate" do
       before :each do
-        @environment = mock("Environment")
-        @interpreter = Interpreter.new(
-          :base_environment => @environment, 
+        @environment = double("Environment")
+        @interpreter = Flea::Interpreter.new(
+          :base_environment => @environment,
           :load_standard_library => false
         )
       end
-      
+
       it "should return the value of a variable" do
-        @environment.should_receive(:find).with(:test).and_return(1)
+        expect(@environment).to receive(:find).with(:test).and_return(1)
         result = @interpreter.evaluate(:test)
-        result.should == 1
+        expect(result).to be == 1
       end
-      
+
       it "should define a variable in the current environment" do
-        @environment.should_receive(:define).with(:test, 1).and_return(1)
+        expect(@environment).to receive(:define).with(:test, 1).and_return(1)
         result = @interpreter.evaluate([:define, :test, 1])
-        result.should == 1
+        expect(result).to be == 1
       end
-      
+
       it "should create a native function" do
         result = @interpreter.evaluate([:native_function, "
           Proc.new() do |arguments, interpreter|
             1
           end
         "])
-        result.should be_a Proc
-        result.call.should == 1        
+        expect(result).to be_a Proc
+        expect(result.call).to be == 1
       end
-      
+
       it "should call a native function" do
-        @environment.should_receive(:find).with(:foo).and_return(Proc.new {|a,b| "bar"})
+        expect(@environment).to receive(:find).with(:foo).and_return(Proc.new {|a,b| "bar"})
         result = @interpreter.evaluate([:foo, 1, 2, 3])
-        result.should == "bar"
+        expect(result).to be == "bar"
       end
-      
+
       [1, 1.0, "string"].each do |literal|
         it "should return literal '#{literal}' as is" do
           result = @interpreter.evaluate(literal)
-          result.should be literal
+          expect(result).to be literal
         end
       end
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/addition_operator_spec.rb
+++ b/spec/flea/standard_library/addition_operator_spec.rb
@@ -5,19 +5,19 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should add several numbers" do
       result = @interpreter.run('(+ 1 2 3)')
-      result.should == 6
+      expect(result).to be == 6
     end
-    
+
     it "should evaluate its arguments before adding them" do
       result = @interpreter.run('
         (define a 2)
         (+ a a a)
       ')
-      result.should == 6
+      expect(result).to be == 6
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/append_spec.rb
+++ b/spec/flea/standard_library/append_spec.rb
@@ -5,13 +5,13 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "union of two lists" do
       result = @interpreter.run('
         (append (quote (1 2 3)) (quote (1 2 3)))
       ')
-      result.should == [1, 2, 3, 1, 2, 3]
+      expect(result).to be == [1, 2, 3, 1, 2, 3]
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/begin_spec.rb
+++ b/spec/flea/standard_library/begin_spec.rb
@@ -5,16 +5,16 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-  
+
     it "should execute each expression after the begin call and return final value" do
       result = @interpreter.run('
         (begin
           (define test 1)
           (set! test 2))
       ')
-      result.should == 2
-      @interpreter.base_environment.find(:test).should == 2
+      expect(result).to be == 2
+      expect(@interpreter.base_environment.find(:test)).to be == 2
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/car_spec.rb
+++ b/spec/flea/standard_library/car_spec.rb
@@ -5,13 +5,13 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should return first item of list" do
       result = @interpreter.run('
         (car (quote (10 2 2)))
       ')
-      result.should == 10
+      expect(result).to be == 10
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/cdr_spec.rb
+++ b/spec/flea/standard_library/cdr_spec.rb
@@ -5,13 +5,13 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should return remainder of list" do
       result = @interpreter.run('
         (cdr (quote (10 2 2)))
       ')
-      result.should == [2, 2]
+      expect(result).to be == [2, 2]
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/cons_spec.rb
+++ b/spec/flea/standard_library/cons_spec.rb
@@ -5,21 +5,21 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should create a list from an atom and an empty list" do
       result = @interpreter.run("(cons 'a '())")
-      result.should == [:a]
+      expect(result).to be == [:a]
     end
-    
+
     it "should create a list from a pair of lists" do
       result = @interpreter.run("(cons '(a) '(b c d))")
-      result.should == [[:a], :b, :c, :d]
+      expect(result).to be == [[:a], :b, :c, :d]
     end
-    
+
     it "should push an atom on an existing list" do
       result = @interpreter.run('(cons "a" \'(b c ))')
-      result.should == ["a", :b, :c]
+      expect(result).to be == ["a", :b, :c]
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/display_spec.rb
+++ b/spec/flea/standard_library/display_spec.rb
@@ -8,27 +8,27 @@ describe "Standard Library" do
       @buffer = StringIO.new
       $stdout = @buffer
     end
-    
+
     it "should output simple literal" do
       @interpreter.run('(display 1)')
-      @buffer.string.should == "1"
+      expect(@buffer.string).to be == "1"
     end
-    
+
     it "should output a list" do
       @interpreter.run('(display (quote (1 2 3)))')
-      @buffer.string.should == "(1 2 3)"
+      expect(@buffer.string).to be == "(1 2 3)"
     end
-    
+
     it "should output true and false using Scheme external representation" do
       @interpreter.run('(display #t)(display #f)')
-      @buffer.string.should == "#t#f"
+      expect(@buffer.string).to be == "#t#f"
     end
-    
+
     it "should return the same value that it displayed" do
       result = @interpreter.run('(display "abc")')
-      result.should == "abc"
+      expect(result).to be == "abc"
     end
-    
+
     after :each do
       $stdout = @old_stdout
     end

--- a/spec/flea/standard_library/division_operator_spec.rb
+++ b/spec/flea/standard_library/division_operator_spec.rb
@@ -5,25 +5,25 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should divide several integers" do
       result = @interpreter.run('(/ 10 2 2)')
-      result.should == 2
+      expect(result).to be == 2
     end
-    
+
     it "should divide several floats" do
       result = @interpreter.run('(/ 10.0 2 2)')
-      result.should == 2.5
+      expect(result).to be == 2.5
     end
-    
+
     it "should evaluate its arguments before dividing them" do
       result = @interpreter.run('
         (define a 2)
         (define b 10)
         (/ b a a)
       ')
-      result.should == 2
+      expect(result).to be == 2
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/equality_operator_spec.rb
+++ b/spec/flea/standard_library/equality_operator_spec.rb
@@ -5,41 +5,41 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     context "for an expression that should evaluate to true" do
       it "should return the equality of several arguments" do
         result = @interpreter.run('
           (= 2 2 2)
         ')
-        result.should == true
+        expect(result).to be == true
       end
-      
+
       it "should evaluate its arguments before comparing them" do
         result = @interpreter.run('
           (define a 2)
           (= a a a)
         ')
-        result.should == true
+        expect(result).to be == true
       end
     end
-    
+
     context "for an expression that should evaluate to false" do
       it "should return the equality of several arguments" do
         result = @interpreter.run('
           (= 2 2 4)
         ')
-        result.should == false
+        expect(result).to be == false
       end
-      
+
       it "should evaluate its arguments before comparing them" do
         result = @interpreter.run('
           (define a 2)
           (define b 3)
           (= a a b)
         ')
-        result.should == false
+        expect(result).to be == false
       end
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/gets_spec.rb
+++ b/spec/flea/standard_library/gets_spec.rb
@@ -8,16 +8,16 @@ describe "Standard Library" do
       @buffer = StringIO.new
       $stdin = @buffer
     end
-    
+
     it "should get input from STDIN" do
       @buffer.string = "test\n"
       result = @interpreter.run('(gets)')
-      result.should == "test\n"
+      expect(result).to be == "test\n"
     end
-    
+
     after :each do
       $stdin = @old_stdin
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/greater_than_spec.rb
+++ b/spec/flea/standard_library/greater_than_spec.rb
@@ -5,25 +5,25 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "return true if it's first argument is larger than all the others" do
       result = @interpreter.run('(greater-than? 10 1 2 3 4)')
-      result.should == true
+      expect(result).to be == true
     end
-    
+
     it "return false if it's first argument is not larger than all the others" do
       result = @interpreter.run('(greater-than? 10 1 2 3 45)')
-      result.should == false
+      expect(result).to be == false
     end
-    
+
     it "should evaluate its arguments" do
       result = @interpreter.run('
         (define a 2)
         (define b 10)
         (greater-than? b a a)
       ')
-      result.should == true
+      expect(result).to be == true
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/if_spec.rb
+++ b/spec/flea/standard_library/if_spec.rb
@@ -5,34 +5,34 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     context "only with consequent" do
       it "should execute consequent" do
         @interpreter.run('
           (if #t
             (define consequent 1))
         ')
-        @interpreter.base_environment.should have_variable :consequent
+        expect(@interpreter.base_environment).to have_variable :consequent
       end
-      
+
       it "should not execute consequent" do
         @interpreter.run('
           (if #f
             (define consequent 1))
         ')
-        @interpreter.base_environment.should_not have_variable :consequent
+        expect(@interpreter.base_environment).to_not have_variable :consequent
       end
-      
+
       it "should evaluate arguments before deciding on execution" do
         @interpreter.run('
           (define test #t)
           (if test
             (define consequent 1))
         ')
-        @interpreter.base_environment.should have_variable :consequent
+        expect(@interpreter.base_environment).to have_variable :consequent
       end
     end
-    
+
     context "with consequent and alternative" do
       it "should execute alternative" do
         @interpreter.run('
@@ -40,20 +40,20 @@ describe "Standard Library" do
             (define consequent 1)
             (define alternative 1))
         ')
-        @interpreter.base_environment.should_not have_variable :consequent
-        @interpreter.base_environment.should have_variable :alternative
+        expect(@interpreter.base_environment).to_not have_variable :consequent
+        expect(@interpreter.base_environment).to have_variable :alternative
       end
-      
+
       it "should execute consequent" do
         @interpreter.run('
           (if #t
             (define consequent 1)
             (define alternative 1))
         ')
-        @interpreter.base_environment.should have_variable :consequent
-        @interpreter.base_environment.should_not have_variable :alternative
+        expect(@interpreter.base_environment).to have_variable :consequent
+        expect(@interpreter.base_environment).to_not have_variable :alternative
       end
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/lambda_spec.rb
+++ b/spec/flea/standard_library/lambda_spec.rb
@@ -8,63 +8,64 @@ describe "Standard Library" do
       @buffer = StringIO.new
       $stdout = @buffer
     end
-    
+
     after :each do
       $stdout = @old_stdout
     end
-    
+
     it "should create a lambda that takes no arguments" do
       result = @interpreter.run('
         (lambda () ())
       ')
-      result.should be_a Proc
+      expect(result).to be_a Proc
     end
 
     it "should create and execute a lambda that takes no arguments" do
       result = @interpreter.run('
-        ((lambda () 
+        ((lambda ()
           (display 1)))
       ')
-      result.should == 1
+      expect(result).to be == 1
     end
-    
+
     it "should create a lambda that takes a single argument" do
       result = @interpreter.run('
         (lambda a ())
       ')
-      result.should be_a Proc
+      expect(result).to be_a Proc
     end
-    
+
     it "should take list as single argument" do
       result = @interpreter.run('
         ((lambda a
           (display a)) 1 2 3)
       ')
-      result.should == [1, 2, 3]
+      expect(result).to be == [1, 2, 3]
     end
-    
+
     it "should create a lambda that takes multiple arguments" do
       result = @interpreter.run('
         (lambda (a b c) ())
       ')
-      result.should be_a Proc
+      expect(result).to be_a Proc
     end
-    
+
     it "should create aand execute a lambda that takes multiple arguments" do
       result = @interpreter.run('
         ((lambda (a b c)
           (display (+ a b c))) 1 2 3)
       ')
-      result.should == 6
+      expect(result).to be == 6
     end
-    
+
     it "should raise an error when lamda is defined using same argument name more than once" do
-      lambda {
+      result = lambda {
         @interpreter.run('
           (lambda (a a a) ())
         ')
-      }.should raise_error
+      }
+      expect(result).to raise_error(RuntimeError)
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/less_than_spec.rb
+++ b/spec/flea/standard_library/less_than_spec.rb
@@ -5,25 +5,25 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "return true if it's first argument is smaller than all the others" do
       result = @interpreter.run('(less-than? 5 10 15 20)')
-      result.should == true
+      expect(result).to be == true
     end
-    
+
     it "return false if it's first argument is not smaller than all the others" do
       result = @interpreter.run('(less-than? 10 1 2 3 45)')
-      result.should == false
+      expect(result).to be == false
     end
-    
+
     it "should evaluate its arguments" do
       result = @interpreter.run('
         (define a 2)
         (define b 10)
         (less-than? b a a)
       ')
-      result.should == false
+      expect(result).to be == false
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/list_predicate_spec.rb
+++ b/spec/flea/standard_library/list_predicate_spec.rb
@@ -5,21 +5,21 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should should return true for an empty list" do
       result = @interpreter.run("(list? '())")
-      result.should == true
+      expect(result).to be == true
     end
-    
+
     it "return true for a populated list" do
       result = @interpreter.run("(list? '(a b c))")
-      result.should == true
+      expect(result).to be == true
     end
-    
+
     it "should return false for an atom" do
       result = @interpreter.run("(list? 'a)")
-      result.should == false
+      expect(result).to be == false
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/list_spec.rb
+++ b/spec/flea/standard_library/list_spec.rb
@@ -5,20 +5,20 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should create a list from it's arguments" do
       result = @interpreter.run('(list 9 2 2)')
-      result.should == [9, 2, 2]
+      expect(result).to be == [9, 2, 2]
     end
-    
+
     it "should evaluate its arguments before creating the list" do
       result = @interpreter.run('
         (define a 2)
         (define b 9)
         (list b a a)
       ')
-      result.should == [9, 2, 2]
+      expect(result).to be == [9, 2, 2]
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/list_tail_spec.rb
+++ b/spec/flea/standard_library/list_tail_spec.rb
@@ -5,13 +5,13 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should return trailing subset of list" do
       result = @interpreter.run('
         (list-tail (quote (1 2 3 4 5)) 2)
       ')
-      result.should == [3, 4, 5]
+      expect(result).to be == [3, 4, 5]
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/mutiplication_operator_spec.rb
+++ b/spec/flea/standard_library/mutiplication_operator_spec.rb
@@ -5,19 +5,19 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should multiply several numbers" do
       result = @interpreter.run('(* 2 2 2)')
-      result.should == 8
+      expect(result).to be == 8
     end
-    
+
     it "should evaluate its arguments before multiplying them" do
       result = @interpreter.run('
         (define a 2)
         (* a a a)
       ')
-      result.should == 8
+      expect(result).to be == 8
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/null_spec.rb
+++ b/spec/flea/standard_library/null_spec.rb
@@ -5,22 +5,22 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-  
+
     it "should return true for an empty list" do
       result = @interpreter.run('
         (null? \'())
       ')
-      result.should == true
+      expect(result).to be == true
     end
-    
+
     ["1", '"abc"', "(1 2 3)"].each do |value|
       it "should return false for #{value}" do
         result = @interpreter.run("
           (null? (quote #{value}))
         ")
-        result.should == false
+        expect(result).to be == false
       end
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/quote_spec.rb
+++ b/spec/flea/standard_library/quote_spec.rb
@@ -5,16 +5,16 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should quote a list" do
       result = @interpreter.run('(quote (1 2 3))')
-      result.should == [1, 2, 3]
+      expect(result).to be == [1, 2, 3]
     end
-    
+
     it "should quote a single literal" do
       result = @interpreter.run('(quote 1)')
-      result.should == 1
+      expect(result).to be == 1
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/rand_spec.rb
+++ b/spec/flea/standard_library/rand_spec.rb
@@ -5,21 +5,21 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     10.times do
       it "should return a random number lower than or equal to 10" do
         result = @interpreter.run('(rand 10)')
-        result.should < 11
+        expect(result).to be < 11
       end
-      
+
       it "should evaluate its arguments" do
         result = @interpreter.run('
           (define a 10)
           (rand a)
         ')
-        result.should < 11
+        expect(result).to be < 11
       end
     end
-  
+
   end
 end

--- a/spec/flea/standard_library/read_spec.rb
+++ b/spec/flea/standard_library/read_spec.rb
@@ -8,16 +8,16 @@ describe "Standard Library" do
       @buffer = StringIO.new
       $stdin = @buffer
     end
-    
+
     it "should read data structure from STDIN" do
       @buffer.string = "(1 2.0 test (1 2 3))\n"
       result = @interpreter.run('(read)')
-      result.should == [[1, 2.0, :test, [1, 2, 3]]]
+      expect(result).to be == [[1, 2.0, :test, [1, 2, 3]]]
     end
-    
+
     after :each do
       $stdin = @old_stdin
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/set_spec.rb
+++ b/spec/flea/standard_library/set_spec.rb
@@ -5,19 +5,20 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should change the value of an existing variable" do
       @interpreter.run('
         (define test 1)
         (set! test 2)')
-      @interpreter.base_environment.find(:test).should == 2
+      expect(@interpreter.base_environment.find(:test)).to be == 2
     end
-    
+
     it "should raise error when attempting to set unbound variable" do
-      lambda {
+      result = lambda {
         @interpreter.run('(set! test 1)')
-      }.should raise_error
+      }
+      expect(result).to raise_error(RuntimeError)
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/string_to_num_spec.rb
+++ b/spec/flea/standard_library/string_to_num_spec.rb
@@ -5,24 +5,24 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should convert string to integer" do
       result = @interpreter.run('(string-to-num "10")')
-      result.should == 10
+      expect(result).to be == 10
     end
-    
+
     it "should convert string to float" do
       result = @interpreter.run('(string-to-num "23.0")')
-      result.should == 23.0
+      expect(result).to be == 23.0
     end
-    
+
     it "should evaluate its arguments" do
       result = @interpreter.run('
         (define a 2)
         (string-to-num a)
       ')
-      result.should == 2
+      expect(result).to be == 2
     end
-    
+
   end
 end

--- a/spec/flea/standard_library/subtraction_operator_spec.rb
+++ b/spec/flea/standard_library/subtraction_operator_spec.rb
@@ -5,20 +5,20 @@ describe "Standard Library" do
     before :each do
       @interpreter = Flea::Interpreter.new
     end
-    
+
     it "should subtract several numbers" do
       result = @interpreter.run('(- 9 2 2)')
-      result.should == 5
+      expect(result).to be == 5
     end
-    
+
     it "should evaluate its arguments before subtracting them" do
       result = @interpreter.run('
         (define a 2)
         (define b 9)
         (- b a a)
       ')
-      result.should == 5
+      expect(result).to be == 5
     end
-    
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,7 @@ require_files << File.join(File.dirname(__FILE__), '..', 'lib',  'flea.rb')
 require_files.each do |file|
   require File.expand_path(file)
 end
+
+RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
+end


### PR DESCRIPTION
This is a great project. I think I'll have a lot of fun with this.

However, when I tried to run the specs for this, I got lots of deprecation warnings. Probably because the latest version of RSpec was installed. Also, two tests were false positives because `raise_error` didn't specify what error was expected, and a different one was raised.

This PR:

- Updates `Rakefile` to explicitly use version 3.3.0 of RSpec and adapts all
specs to use the new `:expect` instead of the deprecated `:should` form.
- Updates `Rakefile` to use fixed versions of all dependencies (`rake install` was complaining about the absence of versions)
- Adds `gemspec.license = "MIT"` to Rakefile to remove another warning from `rake install`.
- Fixes some minor bugs in `lambda.scm` and `set.scm`
- Has RSpec raise on deprecations
- Explicitly uses `Flea::Environment` and `Flea::Interpreter` in the specs because they were failing because of it (tbh, I haven't investigated why).

The trailing white space removal is from my editor. Let me know if it bothers you.